### PR TITLE
Allow passing nest application options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -79,6 +79,9 @@ functions:
 | warmup.source        | Check for aws event source (`context.source === warmup.source`), if equal it will return string `Lambda is warm!`. See [serverless-plugin-warmup](https://github.com/FidelLimited/serverless-plugin-warmup) |
 | fastify.options      | Fastify options. See [options](https://github.com/fastify/fastify/blob/master/docs/Server.md) |
 | fastify.binaryTypes  | List of binaries for Fastify. See [aws-lambda-fastify](https://github.com/fastify/aws-lambda-fastify) |
+| nestjs.options      | NestJs application options. See [NestApplicationOptions](https://github.com/nestjs/nest/blob/master/packages/common/interfaces/nest-application-options.interface.ts) |
+| nestjs.onBeforeInit  | Function called before the `app.init()` is invoked |
+| nestjs.onAfterInit  | Function called after the `app.init()` is invoked |
 
 ## Examples
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,7 +12,7 @@ export interface Options {
     options?: any;
     binaryTypes?: string[];
   },
-  nestOptions: NestApplicationOptions
+  nestOptions?: NestApplicationOptions
 }
 
 const bootstrap = async (module: any, opts: Options): Promise<any> => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcoreplus/nestjs-aws-serverless",
-  "version": "1.0.12",
+  "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gcoreplus/nestjs-aws-serverless",
-  "version": "1.0.12",
+  "version": "1.1.12",
   "description": "Provides default handler for nestjs on lambda",
   "author": "Rennan Stefan Boni",
   "main": "./dist/index.js",


### PR DESCRIPTION
I have recently used this lib and faced a problem where we can't enable cors in the lambdas doing:

`app.enableCors()`

It is possible to enable in each individual controller by specifying a middleware, I think being able to pass a _NestApplicationOptions_ object as a parameter would be very helpful.

I just added an additional field to the _Options_ interface:

`
  ...
  fastify?: {
    options?: any;
    binaryTypes?: string[];
  },
  nestOptions?: NestApplicationOptions
}
`

Note: It may be a good idea to allow an app factory(like the bootstrap function) function, so the user may be able to instantiate the app and configure global middlewares, swagger, etc. as usual.